### PR TITLE
maint(docker): cache Rust dependencies during image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+target/
+.git/
+.gitignore
+.cursor/
+.vscode/
+.idea/
+
+*.log
+*.tmp
+*.sqlite
+*.db
+
+.env
+.env.*
+
+agent-transcripts/
+terminals/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -37,23 +37,6 @@ This will:
 3. Use the environment variables from your `.env` file
 4. Store the database inside the container at `/app/kittyscape.db`
 
-## Verifying Docker Build Cache Reuse
-
-The Dockerfile uses `cargo-chef` to cache Rust dependencies separately from app code.
-
-To verify caching is working:
-
-1. Run an initial build (this compiles dependencies):
-   ```
-   docker build --progress=plain -t kittyscape-bot .
-   ```
-2. Make a small source-only change (for example add a temporary comment in a file under `src/`).
-3. Build again:
-   ```
-   docker build --progress=plain -t kittyscape-bot .
-   ```
-4. In the second build output, confirm the `cargo chef cook --release --recipe-path recipe.json` step is reused from cache (`CACHED`) and only final app compile steps rerun.
-
 ## Viewing Logs
 
 To see the bot's logs:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -37,6 +37,23 @@ This will:
 3. Use the environment variables from your `.env` file
 4. Store the database inside the container at `/app/kittyscape.db`
 
+## Verifying Docker Build Cache Reuse
+
+The Dockerfile uses `cargo-chef` to cache Rust dependencies separately from app code.
+
+To verify caching is working:
+
+1. Run an initial build (this compiles dependencies):
+   ```
+   docker build --progress=plain -t kittyscape-bot .
+   ```
+2. Make a small source-only change (for example add a temporary comment in a file under `src/`).
+3. Build again:
+   ```
+   docker build --progress=plain -t kittyscape-bot .
+   ```
+4. In the second build output, confirm the `cargo chef cook --release --recipe-path recipe.json` step is reused from cache (`CACHED`) and only final app compile steps rerun.
+
 ## Viewing Logs
 
 To see the bot's logs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,43 @@
-# Build stage
-FROM rust:1.86-slim-bullseye as builder
+# syntax=docker/dockerfile:1.7
+
+# Base image shared by planner and builder
+FROM rust:1.86-slim-bullseye AS base
 
 WORKDIR /usr/src/app
 
-# Install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libssl-dev pkg-config libsqlite3-dev ca-certificates && \
+    pkg-config libssl-dev libsqlite3-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# Install sqlx-cli for migrations
-RUN cargo install sqlx-cli --no-default-features --features native-tls,sqlite
+RUN cargo install cargo-chef --locked
 
-# Copy over manifests and lock files
-COPY Cargo.toml Cargo.lock ./
+# Planner stage: build dependency recipe
+FROM base AS planner
 
-# Copy source code
-COPY src/ ./src/
-COPY .sqlx/ ./.sqlx/
-COPY migrations/ ./migrations/
-COPY scripts/ ./scripts/
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Build the application
-RUN cargo build --release
+# Builder stage: cache dependencies, then compile app
+FROM base AS builder
+
+COPY --from=planner /usr/src/app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+RUN cargo build --release --bin kittyscape-loot-bot
 
 # Runtime stage
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS runtime
 
 WORKDIR /app
 
-# Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libssl1.1 libsqlite3-0 ca-certificates strace && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy the built binary
-COPY --from=builder /usr/src/app/target/release/kittyscape-loot-bot /app/
+COPY --from=builder /usr/src/app/target/release/kittyscape-loot-bot /app/kittyscape-loot-bot
 COPY --from=builder /usr/src/app/migrations/ /app/migrations/
 
-# Set up the entrypoint
-CMD ["/app/kittyscape-loot-bot"] 
+CMD ["/app/kittyscape-loot-bot"]


### PR DESCRIPTION
## Summary
- Convert the Docker build to a cargo-chef multi-stage flow (`prepare` + `cook`) so dependency compilation is cached across source-only edits.
- Keep the runtime image behavior the same while copying the release binary from the new builder stage.
- Add a Rust-focused `.dockerignore` to reduce cache invalidation from local artifacts and editor metadata.

## Test plan
- [x] Run `cargo build` locally.
- [ ] Build image once: `docker build -t kittyscape-bot .`.
- [ ] Change a Rust source file and rebuild; verify dependency layers are reused and rebuild is faster.

Made with [Cursor](https://cursor.com)